### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ for your configuration.
  $ cd ~/.emacs.d && make
 ```
 
-The above command will install [Cask](https://github/cask/cask) and
+The above command will install [Cask](https://github.com/cask/cask) and
 all the emacs extensions described in the `Cask` file.


### PR DESCRIPTION
This PR fixes the broken link to the cask repo in `README.md`
