### PR TITLE
Remove pipe from make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ cask    = $(caskdir)/cask/bin/cask
 
 $(caskdir):
 	mkdir $@
-$(cask): | $(caskdir)
+$(cask): $(caskdir)
 	cd $^ && git clone $(caskgit)
 
 .PHONY: dependencies


### PR DESCRIPTION
This PR removes the pipe in the make target. That is, the pipe was hiding the git clone target.
